### PR TITLE
Make "/" be highlighted in menu mode

### DIFF
--- a/django_activeurl/utils.py
+++ b/django_activeurl/utils.py
@@ -54,6 +54,8 @@ def check_active(url, element, full_path, css_class, menu):
             if href != '/':
                 # start with logic
                 logic = full_path.startswith(href)
+            elif href == "/" and full_path == "/":
+                logic = True
             else:
                 logic = False
         else:


### PR DESCRIPTION
Currently the "/" path is never highlighted in menu mode. I've added a special case where both full_path and href are "/" so that it is correctly marked as active.
