### PR TITLE
Fix installation on python3 with LC_ALL=C

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
-
+from io import open
 
 classifiers = '''\
 Framework :: Django

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ packages = [
 
 
 def long_description():
-    f = open('README.rst')
+    f = open('README.rst', encoding='utf-8')
     rst = f.read()
     f.close()
     return rst


### PR DESCRIPTION
Installation with python3, in an environment with LC_ALL=C set (and maybe other non-unicode locales),
gives a decoding error when reading the README.rst into the long_description field.
It's probably the last line in de README.rst (the double angle quotation marks).

The file looks like utf-8 to me, so decode it like that...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hellysmile/django-activeurl/14)
<!-- Reviewable:end -->
