### PR TITLE
ignore_params now works with menu="no"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,5 @@ If you contribute to this project, feel free to add yourself!
 - @jor123: https://github.com/jor123
 - @jonashaag: https://github.com/jonashaag
 - @bmispelon: https://github.com/bmispelon
-- @wbphp (Ivan): https://github.com/wbphp:
+- @wbphp (Ivan): https://github.com/wbphp
+- @RossLote: https://github.com/RossLote

--- a/django_activeurl/utils.py
+++ b/django_activeurl/utils.py
@@ -120,7 +120,7 @@ def check_active(url, element, **kwargs):
             href = href._replace(query='')
             full_path = urlparse.urlsplit(
                 kwargs['full_path']
-            )._replace(query='', fragment='')
+            )._replace(query='')
             kwargs['full_path'] = urlparse.urlunsplit(full_path)
 
         # build urlparse object back into string

--- a/django_activeurl/utils.py
+++ b/django_activeurl/utils.py
@@ -118,10 +118,11 @@ def check_active(url, element, **kwargs):
         # cut off get params (?key=var&etc=var2)
         if ignore_params:
             href = href._replace(query='')
-            full_path = urlparse.urlsplit(
-                kwargs['full_path']
-            )._replace(query='')
-            kwargs['full_path'] = urlparse.urlunsplit(full_path)
+            kwargs['full_path'] = urlparse.urlunsplit(
+                urlparse.urlsplit(
+                    kwargs['full_path']
+                )._replace(query='')
+            )
 
         # build urlparse object back into string
         href = urlparse.urlunsplit(href)

--- a/django_activeurl/utils.py
+++ b/django_activeurl/utils.py
@@ -118,6 +118,10 @@ def check_active(url, element, **kwargs):
         # cut off get params (?key=var&etc=var2)
         if ignore_params:
             href = href._replace(query='')
+            full_path = urlparse.urlsplit(
+                kwargs['full_path']
+            )._replace(query='', fragment='')
+            kwargs['full_path'] = urlparse.urlunsplit(full_path)
 
         # build urlparse object back into string
         href = urlparse.urlunsplit(href)

--- a/tests/test_activeurl.py
+++ b/tests/test_activeurl.py
@@ -140,6 +140,36 @@ def test_ignore_params():
     inactive_li = li_elements[1]
 
     assert not inactive_li.attrib.get('class', False)
+    
+    
+def test_ignore_params_with_no_menu():
+    template = '''
+        {% activeurl menu="no" ignore_params='yes' %}
+            <ul>
+                <li>
+                    <a href="/page/">page</a>
+                </li>
+                <li>
+                    <a href="/other_page/">other_page</a>
+                </li>
+            </ul>
+        {% endactiveurl %}
+    '''
+
+    context = {'request': requests.get('/page/?foo=bar&bar=foo')}
+    html = render(template, context)
+
+    tree = fragment_fromstring(html)
+    li_elements = tree.xpath('//li')
+
+    active_li = li_elements[0]
+
+    assert active_li.attrib.get('class', False)
+    assert 'active' == active_li.attrib['class']
+
+    inactive_li = li_elements[1]
+
+    assert not inactive_li.attrib.get('class', False)
 
 
 def test_disabled_menu_root_path():

--- a/tests/test_activeurl.py
+++ b/tests/test_activeurl.py
@@ -140,8 +140,8 @@ def test_ignore_params():
     inactive_li = li_elements[1]
 
     assert not inactive_li.attrib.get('class', False)
-    
-    
+
+
 def test_ignore_params_with_no_menu():
     template = '''
         {% activeurl menu="no" ignore_params='yes' %}


### PR DESCRIPTION
If you set ignore params="yes" menu="no" and the full_path contains params then the paths won't match. Here is a fix for it.