### PR TITLE
Don't highlight href="#" (matches <=0.1.9 behaviour)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 
 Here you can find the recent changes to django-activeurl
 
+0.1.12 February 16, 2018
+------------------------
+
+- Ignore href="#" to fix incompatibilities with bootstrap.
+  This matches <= 0.1.9 behaviour.
+
 0.1.11 October 10, 2017
 -----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,9 @@ Features
 * automatic highlighting of parent ``<a>`` tags for menus
 * removes boring / hardcoded stuff from your life!
 
+* href="#" never causes highlighting for compatibility with techniques such as
+  bootstrap nav.
+
 Usage
 =====
 

--- a/django_activeurl/__about__.py
+++ b/django_activeurl/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'django-activeurl'
 __package_name__ = 'django_activeurl'
-__version__ = '0.1.11'
+__version__ = '0.1.12'
 __description__ = 'Easy-to-use active URL highlighting for Django'
 __email__ = 'hellysmile@gmail.com'
 __author__ = 'hellysmile'

--- a/django_activeurl/utils.py
+++ b/django_activeurl/utils.py
@@ -109,6 +109,13 @@ def check_active(url, element, **kwargs):
         # get href attribute
         href = url.attrib['href'].strip()
 
+        # href="#" is often used when links shouldn't be handled by browsers.
+        # For example, Bootstrap uses this for expandable menus on
+        # small screens, see
+        # https://getbootstrap.com/docs/4.0/components/navs/#using-dropdowns
+        if href == '#':
+            return False
+
         # split into urlparse object
         href = urlparse.urlsplit(href)
 

--- a/tests/test_activeurl.py
+++ b/tests/test_activeurl.py
@@ -979,6 +979,30 @@ def test_no_valid_html_root_tag():
         pass
 
 
+def test_ignore_href_only_hash():
+    template = '''
+        {% activeurl %}
+            <ul>
+                <li>
+                    <a href="#">page</a>
+                </li>
+                <li>
+                    <a href="/other_page/">other_page</a>
+                </li>
+            </ul>
+        {% endactiveurl %}
+    '''
+
+    context = {'request': requests.get('/page/?foo=bar&bar=foo')}
+    html = render(template, context)
+
+    tree = fragment_fromstring(html)
+    li_elements = tree.xpath('//li')
+
+    assert not li_elements[0].attrib.get('class', False)
+    assert not li_elements[1].attrib.get('class', False)
+
+
 try:
     from jinja2 import Environment, DictLoader
 


### PR DESCRIPTION
Fix for https://github.com/hellysmile/django-activeurl/issues/37