### PR TITLE
Stop infinite exceptions when using ActiveURL on an exception handler template

### DIFF
--- a/django_activeurl/templatetags/activeurl.py
+++ b/django_activeurl/templatetags/activeurl.py
@@ -30,6 +30,8 @@ class ActiveUrl(Tag, Configuration):
         self.load_configuration(**kwargs)
 
         # get request from context
+        if 'request' not in context:
+            return ""
         request = context['request']
 
         # get full path from request


### PR DESCRIPTION
Basically if you had a 500 error and you had a custom 500 error page which used ActiveURL you'd get the following:

```May 17 15:15:28 telltale gunicorn[6284]: [2018-05-17 15:15:28 +0000] [6292] [ERROR] Error handling request /signup/
May 17 15:15:28 telltale gunicorn[6284]: Traceback (most recent call last):
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/exception.py", line 35, in inner
May 17 15:15:28 telltale gunicorn[6284]:     response = get_response(request)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/base.py", line 128, in _get_response
May 17 15:15:28 telltale gunicorn[6284]:     response = self.process_exception_by_middleware(e, request)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/base.py", line 126, in _get_response
May 17 15:15:28 telltale gunicorn[6284]:     response = wrapped_callback(request, *callback_args, **callback_kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/views/generic/base.py", line 69, in view
May 17 15:15:28 telltale gunicorn[6284]:     return self.dispatch(request, *args, **kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/utils/decorators.py", line 62, in _wrapper
May 17 15:15:28 telltale gunicorn[6284]:     return bound_func(*args, **kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/home/telltale/telltale/telltale_web/decorator.py", line 25, in wrap
May 17 15:15:28 telltale gunicorn[6284]:     return function(request, *args, **kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/utils/decorators.py", line 58, in bound_func
May 17 15:15:28 telltale gunicorn[6284]:     return func.__get__(self, type(self))(*args2, **kwargs2)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/views/generic/base.py", line 89, in dispatch
May 17 15:15:28 telltale gunicorn[6284]:     return handler(request, *args, **kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/home/telltale/telltale/telltale_web/views/signup.py", line 52, in post
May 17 15:15:28 telltale gunicorn[6284]:     user.email_user(subject, message, from_email='noreply@kryptoslogic.com', html_message=html_message)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/cuser/models.py", line 106, in email_user
May 17 15:15:28 telltale gunicorn[6284]:     send_mail(subject, message, from_email, [self.email], **kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/mail/__init__.py", line 60, in send_mail
May 17 15:15:28 telltale gunicorn[6284]:     return mail.send()
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/mail/message.py", line 294, in send
May 17 15:15:28 telltale gunicorn[6284]:     return self.get_connection(fail_silently).send_messages([self])
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django_mailgun.py", line 177, in send_messages
May 17 15:15:28 telltale gunicorn[6284]:     if self._send(message):
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django_mailgun.py", line 163, in _send
May 17 15:15:28 telltale gunicorn[6284]:     raise MailgunAPIError(response)
May 17 15:15:28 telltale gunicorn[6284]: django_mailgun.MailgunAPIError: <Response [401]>
May 17 15:15:28 telltale gunicorn[6284]: During handling of the above exception, another exception occurred:
May 17 15:15:28 telltale gunicorn[6284]: Traceback (most recent call last):
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/exception.py", line 35, in inner
May 17 15:15:28 telltale gunicorn[6284]:     response = get_response(request)
May 17 15:15:28 telltale gunicorn[6284]:   File "/home/telltale/telltale/telltale_web/middleware/organisation.py", line 10, in __call__
May 17 15:15:28 telltale gunicorn[6284]:     response = self.get_response(request)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/exception.py", line 37, in inner
May 17 15:15:28 telltale gunicorn[6284]:     response = response_for_exception(request, exc)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/exception.py", line 87, in response_for_exception
May 17 15:15:28 telltale gunicorn[6284]:     response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/exception.py", line 126, in handle_uncaught_exception
May 17 15:15:28 telltale gunicorn[6284]:     return callback(request, **param_dict)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/utils/decorators.py", line 142, in _wrapped_view
May 17 15:15:28 telltale gunicorn[6284]:     response = view_func(request, *args, **kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/views/defaults.py", line 75, in server_error
May 17 15:15:28 telltale gunicorn[6284]:     return HttpResponseServerError(template.render())
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/backends/django.py", line 61, in render
May 17 15:15:28 telltale gunicorn[6284]:     return self.template.render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 175, in render
May 17 15:15:28 telltale gunicorn[6284]:     return self._render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 167, in _render
May 17 15:15:28 telltale gunicorn[6284]:     return self.nodelist.render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 943, in render
May 17 15:15:28 telltale gunicorn[6284]:     bit = node.render_annotated(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 910, in render_annotated
May 17 15:15:28 telltale gunicorn[6284]:     return self.render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/loader_tags.py", line 155, in render
May 17 15:15:28 telltale gunicorn[6284]:     return compiled_parent._render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 167, in _render
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 167, in _render
May 17 15:15:28 telltale gunicorn[6284]:     return self.nodelist.render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 943, in render
May 17 15:15:28 telltale gunicorn[6284]:     bit = node.render_annotated(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 910, in render_annotated
May 17 15:15:28 telltale gunicorn[6284]:     return self.render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/loader_tags.py", line 155, in render
May 17 15:15:28 telltale gunicorn[6284]:     return compiled_parent._render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 167, in _render
May 17 15:15:28 telltale gunicorn[6284]:     return self.nodelist.render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 943, in render
May 17 15:15:28 telltale gunicorn[6284]:     bit = node.render_annotated(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/base.py", line 910, in render_annotated
May 17 15:15:28 telltale gunicorn[6284]:     return self.render(context)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/classytags/core.py", line 153, in render
May 17 15:15:28 telltale gunicorn[6284]:     return self.render_tag(context, **kwargs)
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django_activeurl/templatetags/activeurl.py", line 33, in render_tag
May 17 15:15:28 telltale gunicorn[6284]:     request = context['request']
May 17 15:15:28 telltale gunicorn[6284]:   File "/usr/local/lib/python3.5/dist-packages/django/template/context.py", line 83, in __getitem__
May 17 15:15:28 telltale gunicorn[6284]:     raise KeyError(key)
May 17 15:15:28 telltale gunicorn[6284]: KeyError: 'request'
May 17 15:15:28 telltale gunicorn[6284]: During handling of the above exception, another exception occurred:```

And it would go on until it reached about 10 exceptions and would bail. This fix should prevent that from happening