### PR TITLE
docs: Fix simple typo, extenions -> extensions

### DIFF
--- a/django_activeurl/ext/django_jinja.py
+++ b/django_activeurl/ext/django_jinja.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''jinja extenions for django_jinja/django 1.8+'''
+'''jinja extensions for django_jinja/django 1.8+'''
 from __future__ import absolute_import, unicode_literals
 
 from jinja2 import lexer, nodes


### PR DESCRIPTION
There is a small typo in django_activeurl/ext/django_jinja.py.

Should read `extensions` rather than `extenions`.

